### PR TITLE
API017-41 Update notebook to install latest version of folium/branca

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM jupyter/singleuser
 
 USER jovyan
 
-RUN pip install -e git://github.com/python-visualization/folium.git@master#egg=folium
+RUN pip install -e git://github.com/python-visualization/folium.git@8fa74b90d69a0caff125c4de45c977b6d8b73ca4#egg=folium
 
 USER root
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM jupyter/singleuser
 
 USER jovyan
-RUN conda install -c ioos --quiet --yes \
-    'folium=0.2.1' \
-    && conda clean -tipsy
+
+RUN pip install -e git://github.com/python-visualization/folium.git@master#egg=folium
 
 USER root
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Update the Dockerfile to install folium from github master, which will support the latest visualisations in the data repositories. 